### PR TITLE
Make the typeaheads more inline

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -44,7 +44,7 @@ var Dropdown = React.createClass({
     let selected = [taOptions[this.props.selectedIndex]];
 
     return (
-      <div>
+      <div className="vp-dropdown">
         <Typeahead
             options={taOptions}
             selected={selected}

--- a/src/components/graph.less
+++ b/src/components/graph.less
@@ -34,17 +34,17 @@ limitations under the License.
     bottom: 0;
   }
   .vp-graph-axes {
+    display: flex;
+    align-items: center;
     flex-shrink: 0;
     padding: @padding-small @padding-base;
+    span {
+      padding: 0 @padding-small;
+    }
+    .vp-dropdown {
+      flex-grow: 1;
+    }
   }
-
-  div {
-    flex-grow: 0;
-  }
-  .bootstrap-typeahead {
-    width: 35%;
-  }
-
   .vp-graph-viewport {
     flex-grow: 1;
   }


### PR DESCRIPTION
This branch makes the typeaheads more inline with each other and fixes #3

![screen shot 2016-09-15 at 2 10 04 pm](https://cloud.githubusercontent.com/assets/1216917/18567703/3eab3322-7b4e-11e6-9183-d6a9de2a3bf5.png)

cc @MattFerraro 
