### PR TITLE
Multibrush

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
+    "lodash.chunk": "^4.2.0",
+    "lodash.difference": "^4.5.0",
+    "lodash.flatten": "^4.4.0",
     "papaparse": "^4.1.2",
     "platform": "^1.3.1",
     "react-bootstrap": "^0.29.5",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -43,7 +43,9 @@ var App = React.createClass({
       graphCount: 0,
       pointSize: 2,
       overpaintFactor: 3,
-      activeHighlight: 1
+      activeHighlight: 1,
+      yellowBrushOverIndex: 0,
+      greenBrushOverIndex: 0
     };
   },
 
@@ -170,12 +172,10 @@ var App = React.createClass({
   },
 
   _onPointSizeChange: function(pointSize) {
-    // console.log("on point size change");
     this.setState({pointSize: pointSize});
   },
 
   _onOverpaintFactorChange: function(factor) {
-    // console.log("on overpaint change");
     this.setState({overpaintFactor: factor});
   },
 
@@ -183,6 +183,13 @@ var App = React.createClass({
     newHighlightKey -= 1; // correct for stupid off by 1 behavior
     // that comes with react-bootstrap's implementation of tabs
     this.setState({activeHighlight: newHighlightKey});
+  },
+
+  _setYellowBrushOver: function(index) {
+    console.log("set yellow brushover in app.js", index);
+    this.setState({
+      yellowBrushOverIndex: parseFloat(index)
+    });
   },
 
   render: function() {
@@ -208,12 +215,17 @@ var App = React.createClass({
               onColumnsChanged={this._onColumnsChanged}
               options={this.state.options}
               overpaintFactor={this.state.overpaintFactor}
+              yellowBrushOverIndex={this.state.yellowBrushOverIndex}
+              greenBrushOverIndex={this.state.greenBrushOverIndex}
               pointSize={this.state.pointSize}/>
           <Sidebar onPointSizeChange={this._onPointSizeChange}
               activeHighlight={this.state.activeHighlight}
               onHighlightChanged={this._onHighlightChanged}
               overpaintFactor={this.state.overpaintFactor}
               pointSize={this.state.pointSize}
+              yellowBrushOverIndex={this.state.yellowBrushOverIndex}
+              setYellowBrushOver={this._setYellowBrushOver}
+              greenBrushOverIndex={this.state.greenBrushOverIndex}
               onOverpaintFactorChange={this._onOverpaintFactorChange}/>
         </div>
       </div>);

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -42,7 +42,8 @@ var App = React.createClass({
       loadPercent: 0,
       graphCount: 0,
       pointSize: 2,
-      overpaintFactor: 3
+      overpaintFactor: 3,
+      activeHighlight: 1
     };
   },
 
@@ -178,6 +179,12 @@ var App = React.createClass({
     this.setState({overpaintFactor: factor});
   },
 
+  _onHighlightChanged: function(newHighlightKey) {
+    newHighlightKey -= 1; // correct for stupid off by 1 behavior
+    // that comes with react-bootstrap's implementation of tabs
+    this.setState({activeHighlight: newHighlightKey});
+  },
+
   render: function() {
     return (
       <div className="vp-app">
@@ -193,7 +200,9 @@ var App = React.createClass({
           </div>}
         </div>
         <div className="vp-content">
-          <Graphs columns={this.state.columns}
+          <Graphs
+              activeHighlight={this.state.activeHighlight}
+              columns={this.state.columns}
               count={this.state.graphCount}
               enums={this.state.enums}
               onColumnsChanged={this._onColumnsChanged}
@@ -201,6 +210,8 @@ var App = React.createClass({
               overpaintFactor={this.state.overpaintFactor}
               pointSize={this.state.pointSize}/>
           <Sidebar onPointSizeChange={this._onPointSizeChange}
+              activeHighlight={this.state.activeHighlight}
+              onHighlightChanged={this._onHighlightChanged}
               overpaintFactor={this.state.overpaintFactor}
               pointSize={this.state.pointSize}
               onOverpaintFactorChange={this._onOverpaintFactorChange}/>

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -201,8 +201,8 @@ var App = React.createClass({
               overpaintFactor={this.state.overpaintFactor}
               pointSize={this.state.pointSize}/>
           <Sidebar onPointSizeChange={this._onPointSizeChange}
-              pointSize={this.state.pointSize}
               overpaintFactor={this.state.overpaintFactor}
+              pointSize={this.state.pointSize}
               onOverpaintFactorChange={this._onOverpaintFactorChange}/>
         </div>
       </div>);

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -186,9 +186,14 @@ var App = React.createClass({
   },
 
   _setYellowBrushOver: function(index) {
-    console.log("set yellow brushover in app.js", index);
     this.setState({
       yellowBrushOverIndex: parseFloat(index)
+    });
+  },
+
+  _setGreenBrushOver: function(index) {
+    this.setState({
+      greenBrushOverIndex: parseFloat(index)
     });
   },
 
@@ -225,6 +230,7 @@ var App = React.createClass({
               pointSize={this.state.pointSize}
               yellowBrushOverIndex={this.state.yellowBrushOverIndex}
               setYellowBrushOver={this._setYellowBrushOver}
+              setGreenBrushOver={this._setGreenBrushOver}
               greenBrushOverIndex={this.state.greenBrushOverIndex}
               onOverpaintFactorChange={this._onOverpaintFactorChange}/>
         </div>

--- a/src/components/graph.js
+++ b/src/components/graph.js
@@ -24,12 +24,11 @@ var Graph = React.createClass({
 
   propTypes: {
     axesClassName: React.PropTypes.string,
+    brushes: React.PropTypes.array,
     className: React.PropTypes.string,
     columns: React.PropTypes.array,
     enums: React.PropTypes.array,
     highlightFunction: React.PropTypes.func,
-    highlightedIndicesArrays: React.PropTypes.array,
-    normalIndicesArrays: React.PropTypes.array,
     options: React.PropTypes.arrayOf(React.PropTypes.string),
     overpaintFactor: React.PropTypes.number,
     pointSize: React.PropTypes.number,
@@ -123,16 +122,18 @@ var Graph = React.createClass({
       var urls = [];
 
       var minimumHighlightedIndices = [];
-      for (let i = 0; i < this.props.highlightedIndicesArrays.length; i++) {
-        var highlightedIndices = this.props.highlightedIndicesArrays[i];
-        for (var j = 0; j < highlightedIndices.length; j++) {
-          minimumHighlightedIndices.push(highlightedIndices[j] + i * maxPerArray);
+      for (let b = 0; b < this.props.brushes.length; b++) {
+        for (let i = 0; i < this.props.brushes[b].length; i++) {
+          var highlightedIndices = this.props.brushes[b][i];
+          for (var j = 0; j < highlightedIndices.length; j++) {
+            minimumHighlightedIndices.push(highlightedIndices[j] + i * maxPerArray);
+            if (minimumHighlightedIndices.length == numThumbs) {
+              break
+            }
+          }
           if (minimumHighlightedIndices.length == numThumbs) {
             break
           }
-        }
-        if (minimumHighlightedIndices.length == numThumbs) {
-          break
         }
       }
 
@@ -158,8 +159,7 @@ var Graph = React.createClass({
           enums={this.props.enums}
           height={this.state.viewportHeight}
           highlightFunction={this.props.highlightFunction}
-          highlightedIndicesArrays={this.props.highlightedIndicesArrays}
-          normalIndicesArrays={this.props.normalIndicesArrays}
+          brushes={this.props.brushes}
           options={this.props.options}
           overpaintFactor={this.props.overpaintFactor}
           pointSize={this.props.pointSize}

--- a/src/components/graphs.js
+++ b/src/components/graphs.js
@@ -19,10 +19,8 @@
 
 var React = require('react');
 var Graph = require('./graph');
-var chunk = require('lodash/chunk');
 var difference = require('lodash/difference');
 var intersection = require('lodash/intersection');
-var flatten = require('lodash/flatten');
 var maxPerArray = 65530;
 var numBrushes = 4;
 
@@ -204,9 +202,16 @@ var Graphs = React.createClass({
       highlightedIndicesArrays.push(highlightedIndices);
     }
 
+    let andBucket = [];
     if (this.props.activeHighlight == 3) {
-      let andBucket = this.state.brushes[this.props.yellowBrushOverIndex];
+      andBucket = this.state.brushes[this.props.yellowBrushOverIndex];
+    }
 
+    if (this.props.activeHighlight == 2) {
+      andBucket = this.state.brushes[this.props.greenBrushOverIndex];
+    }
+
+    if (this.props.activeHighlight >= 2) {
       for (let i = 0; i < andBucket.length; i++) {
         let subAndBucket = andBucket[i];
         let subHighlighted = highlightedIndicesArrays[i];

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -36,7 +36,8 @@ var Sidebar = React.createClass({
     onHighlightChanged: React.PropTypes.func,
     yellowBrushOverIndex: React.PropTypes.number,
     greenBrushOverIndex: React.PropTypes.number,
-    setYellowBrushOver: React.PropTypes.func
+    setYellowBrushOver: React.PropTypes.func,
+    setGreenBrushOver: React.PropTypes.func
   },
 
   _onPointSizeChange: function(event) {
@@ -48,7 +49,6 @@ var Sidebar = React.createClass({
   },
 
   _setYellowBrushOverIndex: function(index) {
-    console.log("setting yellow brush over index", index);
     this.props.setYellowBrushOver(index);
   },
 
@@ -102,7 +102,7 @@ var Sidebar = React.createClass({
       <div>
         <div className="vp-sidebar-item-label">Select From</div>
         <ButtonGroup>
-          <Button active>{redGlyph}</Button>
+          <Button disabled>{redGlyph}</Button>
           <Button disabled>{blueGlyph}</Button>
           <Button disabled>{greenGlyph}</Button>
           <Button disabled>{yellowGlyph}</Button>
@@ -114,9 +114,9 @@ var Sidebar = React.createClass({
       <div>
         <div className="vp-sidebar-item-label">Select From</div>
         <ButtonGroup>
-          <Button active>{redGlyph}</Button>
-          <Button>{blueGlyph}</Button>
-          <Button disabed>{greenGlyph}</Button>
+          <Button value='0' onClick={() => this.props.setGreenBrushOver('0')}>{redGlyph}</Button>
+          <Button value='1' onClick={() => this.props.setGreenBrushOver('1')}>{blueGlyph}</Button>
+          <Button disabled>{greenGlyph}</Button>
           <Button disabled>{yellowGlyph}</Button>
         </ButtonGroup>
       </div>
@@ -126,9 +126,9 @@ var Sidebar = React.createClass({
       <div>
         <div className="vp-sidebar-item-label">Select From</div>
         <ButtonGroup>
-          <Button value='0' onClick={() => this._setYellowBrushOverIndex('0')}>{redGlyph}</Button>
-          <Button value='1' onClick={() => this._setYellowBrushOverIndex('1')}>{blueGlyph}</Button>
-          <Button value='2' onClick={() => this._setYellowBrushOverIndex('2')}>{greenGlyph}</Button>
+          <Button value='0' onClick={() => this.props.setYellowBrushOver('0')}>{redGlyph}</Button>
+          <Button value='1' onClick={() => this.props.setYellowBrushOver('1')}>{blueGlyph}</Button>
+          <Button value='2' onClick={() => this.props.setYellowBrushOver('2')}>{greenGlyph}</Button>
           <Button disabled>{yellowGlyph}</Button>
         </ButtonGroup>
       </div>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -33,7 +33,10 @@ var Sidebar = React.createClass({
     onOverpaintFactorChange: React.PropTypes.func,
     pointSize: React.PropTypes.number,
     activeHighlight: React.PropTypes.number,
-    onHighlightChanged: React.PropTypes.func
+    onHighlightChanged: React.PropTypes.func,
+    yellowBrushOverIndex: React.PropTypes.number,
+    greenBrushOverIndex: React.PropTypes.number,
+    setYellowBrushOver: React.PropTypes.func
   },
 
   _onPointSizeChange: function(event) {
@@ -42,6 +45,11 @@ var Sidebar = React.createClass({
 
   _onOverpaintFactorChange: function(event) {
     this.props.onOverpaintFactorChange(parseFloat(event.target.value));
+  },
+
+  _setYellowBrushOverIndex: function(index) {
+    console.log("setting yellow brush over index", index);
+    this.props.setYellowBrushOver(index);
   },
 
   render: function() {
@@ -73,17 +81,57 @@ var Sidebar = React.createClass({
       }
     ];
 
-    var redGlyph = (<Glyphicon glyph="tint" className='red'/>);
-    var blueGlyph = (<Glyphicon glyph="tint" className='blue'/>);
-    var greenGlyph = (<Glyphicon glyph="tint" className='green'/>);
-    var yellowGlyph = (<Glyphicon glyph="tint" className='yellow'/>);
+    var redGlyph = (<Glyphicon glyph="tint" className='red' value='0'/>);
+    var blueGlyph = (<Glyphicon glyph="tint" className='blue' value='1'/>);
+    var greenGlyph = (<Glyphicon glyph="tint" className='green' value='2'/>);
+    var yellowGlyph = (<Glyphicon glyph="tint" className='yellow' value='3'/>);
 
-    var inside = (
-      <ButtonGroup>
-        <Button>Left</Button>
-        <Button>Middle</Button>
-        <Button>Right</Button>
-      </ButtonGroup>
+    var redInside = (
+      <div>
+        <div className="vp-sidebar-item-label">Select From</div>
+        <ButtonGroup>
+          <Button disabled>{redGlyph}</Button>
+          <Button disabled>{blueGlyph}</Button>
+          <Button disabled>{greenGlyph}</Button>
+          <Button disabled>{yellowGlyph}</Button>
+        </ButtonGroup>
+      </div>
+    )
+
+    var blueInside = (
+      <div>
+        <div className="vp-sidebar-item-label">Select From</div>
+        <ButtonGroup>
+          <Button active>{redGlyph}</Button>
+          <Button disabled>{blueGlyph}</Button>
+          <Button disabled>{greenGlyph}</Button>
+          <Button disabled>{yellowGlyph}</Button>
+        </ButtonGroup>
+      </div>
+    )
+
+    var greenInside = (
+      <div>
+        <div className="vp-sidebar-item-label">Select From</div>
+        <ButtonGroup>
+          <Button active>{redGlyph}</Button>
+          <Button>{blueGlyph}</Button>
+          <Button disabed>{greenGlyph}</Button>
+          <Button disabled>{yellowGlyph}</Button>
+        </ButtonGroup>
+      </div>
+    )
+
+    var yellowInside = (
+      <div>
+        <div className="vp-sidebar-item-label">Select From</div>
+        <ButtonGroup>
+          <Button value='0' onClick={() => this._setYellowBrushOverIndex('0')}>{redGlyph}</Button>
+          <Button value='1' onClick={() => this._setYellowBrushOverIndex('1')}>{blueGlyph}</Button>
+          <Button value='2' onClick={() => this._setYellowBrushOverIndex('2')}>{greenGlyph}</Button>
+          <Button disabled>{yellowGlyph}</Button>
+        </ButtonGroup>
+      </div>
     )
 
     return (
@@ -99,10 +147,10 @@ var Sidebar = React.createClass({
         })}
         <div>
           <Tabs activeKey={this.props.activeHighlight+1} onSelect={this.props.onHighlightChanged} id="controlled-tab">
-            <Tab eventKey={1} title={redGlyph}>{inside}</Tab>
-            <Tab eventKey={2} title={blueGlyph}>{inside}</Tab>
-            <Tab eventKey={3} title={greenGlyph}>{inside}</Tab>
-            <Tab eventKey={4} title={yellowGlyph}>{inside}</Tab>
+            <Tab eventKey={1} title={redGlyph}>{redInside}</Tab>
+            <Tab eventKey={2} title={blueGlyph}>{greenInside}</Tab>
+            <Tab eventKey={3} title={greenGlyph}>{greenInside}</Tab>
+            <Tab eventKey={4} title={yellowGlyph}>{yellowInside}</Tab>
           </Tabs>
         </div>
       </div>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -31,6 +31,8 @@ var Sidebar = React.createClass({
     overpaintFactor: React.PropTypes.number,
     onOverpaintFactorChange: React.PropTypes.func,
     pointSize: React.PropTypes.number,
+    activeHighlight: React.PropTypes.number,
+    onHighlightChanged: React.PropTypes.func
   },
 
   _onPointSizeChange: function(event) {
@@ -82,11 +84,11 @@ var Sidebar = React.createClass({
           )
         })}
         <div>
-          <Tabs defaultActiveKey={2} id="uncontrolled-tab-example">
-            <Tab eventKey={1} title="Red"></Tab>
+          <Tabs activeKey={this.props.activeHighlight+1} onSelect={this.props.onHighlightChanged} id="controlled-tab">
+            <Tab eventKey={1} title="Red">:)</Tab>
             <Tab eventKey={2} title="Blue">Tab 2 content</Tab>
-            <Tab eventKey={3} title="Yellow">Tab 3 content</Tab>
-            <Tab eventKey={4} title="Green">Tab 3 content</Tab>
+            <Tab eventKey={3} title="Green">Tab 3 content</Tab>
+            <Tab eventKey={4} title="Yellow">Hello</Tab>
           </Tabs>
         </div>
       </div>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -22,6 +22,7 @@ var bootstrap = require('react-bootstrap');
 var Tabs = bootstrap.Tabs;
 var Tab = bootstrap.Tab;
 var Button = bootstrap.Button;
+var ButtonGroup = bootstrap.ButtonGroup;
 var Glyphicon = bootstrap.Glyphicon;
 
 var Sidebar = React.createClass({
@@ -72,6 +73,19 @@ var Sidebar = React.createClass({
       }
     ];
 
+    var redGlyph = (<Glyphicon glyph="tint" className='red'/>);
+    var blueGlyph = (<Glyphicon glyph="tint" className='blue'/>);
+    var greenGlyph = (<Glyphicon glyph="tint" className='green'/>);
+    var yellowGlyph = (<Glyphicon glyph="tint" className='yellow'/>);
+
+    var inside = (
+      <ButtonGroup>
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+    )
+
     return (
       <div className="vp-sidebar">
         {items.map(function(item, index) {
@@ -85,10 +99,10 @@ var Sidebar = React.createClass({
         })}
         <div>
           <Tabs activeKey={this.props.activeHighlight+1} onSelect={this.props.onHighlightChanged} id="controlled-tab">
-            <Tab eventKey={1} title="Red">:)</Tab>
-            <Tab eventKey={2} title="Blue">Tab 2 content</Tab>
-            <Tab eventKey={3} title="Green">Tab 3 content</Tab>
-            <Tab eventKey={4} title="Yellow">Hello</Tab>
+            <Tab eventKey={1} title={redGlyph}>{inside}</Tab>
+            <Tab eventKey={2} title={blueGlyph}>{inside}</Tab>
+            <Tab eventKey={3} title={greenGlyph}>{inside}</Tab>
+            <Tab eventKey={4} title={yellowGlyph}>{inside}</Tab>
           </Tabs>
         </div>
       </div>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -18,6 +18,11 @@
 // limitations under the License.
 
 var React = require('react');
+var bootstrap = require('react-bootstrap');
+var Tabs = bootstrap.Tabs;
+var Tab = bootstrap.Tab;
+var Button = bootstrap.Button;
+var Glyphicon = bootstrap.Glyphicon;
 
 var Sidebar = React.createClass({
 
@@ -76,6 +81,14 @@ var Sidebar = React.createClass({
             </div>
           )
         })}
+        <div>
+          <Tabs defaultActiveKey={2} id="uncontrolled-tab-example">
+            <Tab eventKey={1} title="Red"></Tab>
+            <Tab eventKey={2} title="Blue">Tab 2 content</Tab>
+            <Tab eventKey={3} title="Yellow">Tab 3 content</Tab>
+            <Tab eventKey={4} title="Green">Tab 3 content</Tab>
+          </Tabs>
+        </div>
       </div>
     );
   }

--- a/src/components/sidebar.less
+++ b/src/components/sidebar.less
@@ -36,10 +36,10 @@ limitations under the License.
     .vp-sidebar-item-value {
       float: right;
     }
-    .vp-sidebar-item-label {
-      margin-bottom: @padding-small;
-      font-weight: 700;
-    }
+  }
+  .vp-sidebar-item-label {
+    margin-bottom: @padding-small;
+    font-weight: 700;
   }
 
   .blue {

--- a/src/components/sidebar.less
+++ b/src/components/sidebar.less
@@ -41,4 +41,25 @@ limitations under the License.
       font-weight: 700;
     }
   }
+
+  .blue {
+    color: rgb(0, 0, 255);
+  }
+
+  .red {
+    color: rgb(255, 0, 0);
+  }
+
+  .green {
+    color: rgb(0, 255, 0);
+  }
+
+  .yellow {
+    color: rgb(255, 255, 0);
+  }
+
+  .darker {
+    color: rgb(50, 50, 50);
+    background-color: rgb(50, 50, 50);
+  }
 }


### PR DESCRIPTION
This is a fairly substantial change to take us from 1 highlight brush (blue) to 3 highlight brushes (blue, green, yellow). The UI paradigm is substantially different from the original viewpoint's, so let me pitch you the whole idea:

Points do not have a single color. Points exist in the red bucket and can also get copied into the blue, green, or yellow buckets. The buckets will always be drawn in the order red-->blue-->green-->yellow, so if a point appears in multiple buckets, its display color will be whichever is drawn last. In this way, the highlight brushes are somewhat akin to photoshop's idea of layers. A potential improvement in the future is to use a drag + drop list ([like this one](https://jqueryui.com/sortable/)) to order the brushes at will, instead of a hardcoded order. We could also add a check box to optionally hide a brush layer entirely.

In addition, the tab area on the lower right offers plenty of screen real estate to host a color picker, so you could potentially change the colors of the brushes at will.

One interesting wrinkle is what to do with the `i` key, which currently inverts the selection. If I'm using the green brush and I have 10% of the points highlighted, tapping `i` will simply take every point that isn't in the green bucket and put it in the bucket, while taking every point that is already in the green bucket and putting it out. At the end, I will have 90% of the points in the green bucket, and the blue and yellow buckets will remain unchanged. This can be surprising behavior if say, 100% of the points are already in the yellow bucket, because in that case all points will just stay yellow. Still, I think layers is a reasonable abstraction for this concept.

Multiple brushes make it easy to illustrate "OR" ideas. If you highlight the lower quartile in blue and the higher quartile in yellow, you can just say that the highlighted points are in either the higher OR lower quartile. But how do you illustrate an "AND" idea? That requires a new abstraction--the "select from" panel.

By default, if you are highlighting anything, that means you are finding any points from the red bucket which meet a certain range criteria and you are copying them to the blue|green|yellow bucket. The "select from" panel just changes the source bucket from red to another color. Let's do an example.

Say we start with the inline skating file:
<img width="1680" alt="screen shot 2016-09-15 at 8 38 44 pm" src="https://cloud.githubusercontent.com/assets/1302431/18574713/bba6e228-7b84-11e6-911a-e722ac48baa8.png">

On the lower left graph, we see two bunches of points. Let's highlight the bunch that has a high `AngleKnee` and relatively low `MedialGastrocnemius` in blue. This bundle is sufficiently tight that it likely corresponds to something physically meaningful:
<img width="1680" alt="screen shot 2016-09-15 at 8 39 02 pm" src="https://cloud.githubusercontent.com/assets/1302431/18574737/083c749a-7b85-11e6-8d71-b82ac183924c.png">

We can see in the upper right graph that the blue points actually separate into two species: one with low values of `SpeedAnkl` and `SpeedKnee` and one with high values of the same. If we click the yellow tab we are now highlighting with the yellow brush. If we then click `Select From --> blue`, we are going to highlight only from the blue points.

After doing this, we highlight the entire upper half of the upper right graph, and we see the following:
<img width="1680" alt="screen shot 2016-09-15 at 8 39 59 pm" src="https://cloud.githubusercontent.com/assets/1302431/18574825/9365ee02-7b85-11e6-8b55-1a972c2642d5.png">

Looking at the upper left graph we can deduce that if the skater's `AngleKnee` is high AND the `SpeedKnee` is high, the `AngleAnkl` will be rapidly increasing. However, if the `AngleKnee` is high AND the `SpeedKnee` is low, `AngleAnkl` will instead be slowly decreasing. (Actually, to know the difference between increasing and decreasing I had to use the green highlighter on the `Time` graph. I highlighted to the right and saw that the points circled the `AngleKnee` vs `AngleAnkl` clockwise, not anticlockwise)

One final wrinkle: What do I do if the user highlights a region in yellow, then tries to highlight in blue but only from the yellow bucket? If I naively did what the user asks for, they will highlight points into the blue bucket but those points will appear to just stay yellow because the yellow brush takes drawing precedence over blue. This strikes me as behavior that is too surprising, so until I have a sortable list of layers I will just disallow that action. If you're using a low precedence brush like blue, you aren't allowed to hit `select from --> yellow`. The button is just disabled for higher priority brushes.
