### PR TITLE
"vs" button on graphs swaps the axes.

### DIFF
--- a/src/components/graph.js
+++ b/src/components/graph.js
@@ -115,6 +115,15 @@ var Graph = React.createClass({
     this.setState({yAxisSelectedIndex: index});
   },
 
+  _swapAxes: function() {
+    let x = this.state.xAxisSelectedIndex;
+    let y = this.state.yAxisSelectedIndex;
+    this.setState({
+      xAxisSelectedIndex: y,
+      yAxisSelectedIndex: x
+    });
+  },
+
   render: function() {
     if (this.state.thumbnails) {
       var maxPerArray = 65530;  // TODO: pull this into a global variable
@@ -177,7 +186,7 @@ var Graph = React.createClass({
               options={this.state.xOptions}
               ref="xaxis"
               selectedIndex={this.state.xAxisSelectedIndex}/>
-          <span> vs </span>
+          <button className="swap-button" onClick={this._swapAxes}> vs </button>
           <Dropdown onSelect={this._onYAxisSelect}
               options={this.state.yOptions}
               ref="yaxis"

--- a/src/components/graph.less
+++ b/src/components/graph.less
@@ -44,6 +44,9 @@ limitations under the License.
     .vp-dropdown {
       flex-grow: 1;
     }
+    .swap-button {
+      margin: 0 0.2em;
+    }
   }
   .vp-graph-viewport {
     flex-grow: 1;


### PR DESCRIPTION
Changes the "vs" text to a button that swaps the axes.

![2016-09-16-152244_639x443_scrot](https://cloud.githubusercontent.com/assets/64391/18602854/8f868750-7c21-11e6-98b7-203ff2c4ae43.png)

I went with a default unstyled `button` element because if you use boostrap's button styles, you get a flat div with rounded corners, and it didn't look totally obvious to me in this context that it's a UI affordance. Easy enough to change it to a bootstrap style button by adding the `btn` class to the `<button>` element.
